### PR TITLE
Drop net6.0 TFM and add net9.0 TFM

### DIFF
--- a/SmtpToRest.IntegrationTests/SmtpToRest.IntegrationTests.csproj
+++ b/SmtpToRest.IntegrationTests/SmtpToRest.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/SmtpToRest.UnitTests/SmtpToRest.UnitTests.csproj
+++ b/SmtpToRest.UnitTests/SmtpToRest.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/SmtpToRest/SmtpToRest.csproj
+++ b/SmtpToRest/SmtpToRest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
     <Authors>Nicolai Henriksen</Authors>
     <Product>SMTP To REST conversion service</Product>
     <PackageTags>SMTP;REST</PackageTags>


### PR DESCRIPTION
Drops the .NET6 TFM and replaces it with .NET9 in relevant places.

Some project still target .NET8 as this is the latest LTS version.